### PR TITLE
Change prepend depending on RSpec or Minitest

### DIFF
--- a/lib/rails_test_params_backport.rb
+++ b/lib/rails_test_params_backport.rb
@@ -30,5 +30,7 @@ end
 require 'rails_test_params_backport/rails3' if ActiveSupport::VERSION::MAJOR == 3
 require 'rails_test_params_backport/rails4' if ActiveSupport::VERSION::MAJOR == 4
 
+ActionController::TestCase.prepend(RailsTestParamsBackport::TestCase)
 ActionController::TestCase::Behavior.prepend(RailsTestParamsBackport::TestCase)
+
 ActionDispatch::Integration::Session.prepend(RailsTestParamsBackport::IntegrationSession)


### PR DESCRIPTION
:octopus::computer:

/cc @bquorning @grosser 
### Description

Prepending in `Behavior` doesn't cut it for Minitest, and the other way around.
### Steps to merge
- [ ] :+1: from the team
### Risks
- None
