### PR TITLE
More readable specs

### DIFF
--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -6,15 +6,15 @@ describe HomeController, type: :controller do
       get :index, params: { text: 'Hello World!' }
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq('params[:text] = Hello World!')
+      expect(response.body).to include('Text: Hello World!')
     end
 
   describe 'headers'
     it 'accepts headers' do
-      get :headers, headers: { 'HTTP_ACCEPT' => 'text/plain' }
+      get :index, headers: { 'HTTP_ACCEPT' => 'text/plain' }
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq('session[:accept] = text/plain')
+      expect(response.body).to include('Accept: text/plain')
     end
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe HomeController, type: :controller do
+  it 'accepts the path alone' do
+    get :index
+
+    expect(response).to have_http_status(:ok)
+  end
+
   it 'accepts :params' do
     get :index, params: { text: 'Hello World!' }
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,34 +1,29 @@
 require 'spec_helper'
 
 describe HomeController, type: :controller do
-  describe 'index' do
-    it 'accepts :params' do
-      get :index, params: { text: 'Hello World!' }
+  it 'accepts :params' do
+    get :index, params: { text: 'Hello World!' }
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('Text: Hello World!')
-    end
-
-  describe 'headers'
-    it 'accepts headers' do
-      get :index, headers: { 'HTTP_ACCEPT' => 'text/plain' }
-
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('Accept: text/plain')
-    end
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Text: Hello World!')
   end
 
-  describe 'raise on offense' do
-    it 'raises when an unexpected parameter is passed' do
-      expect {
-        get :index, wrong: true
-      }.to raise_error(RailsTestParamsBackport::ParameterError)
-    end
+  it 'accepts headers' do
+    get :index, headers: { 'HTTP_ACCEPT' => 'text/plain' }
 
-    it 'raises when headers are sent in a separate hash' do
-      expect {
-        get :index, {}, { 'HTTP_ACCEPT' => 'text/plain' }
-      }.to raise_error(RailsTestParamsBackport::ParameterError)
-    end
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Accept: text/plain')
+  end
+
+  it 'raises when an unexpected parameter is passed' do
+    expect {
+      get :index, wrong: true
+    }.to raise_error(RailsTestParamsBackport::ParameterError)
+  end
+
+  it 'raises when headers are sent in a separate hash' do
+    expect {
+      get :index, {}, { 'HTTP_ACCEPT' => 'text/plain' }
+    }.to raise_error(RailsTestParamsBackport::ParameterError)
   end
 end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,10 +1,6 @@
 class HomeController < ApplicationController
   def index
-    render text: "params[:text] = #{params[:text]}"
-  end
-
-  def headers
-    render text: "session[:accept] = #{accept_header}"
+    render text: "Text: #{params[:text]} - Accept: #{accept_header}"
   end
 
   private

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,3 @@
 Rails.application.routes.draw do
-  resources :home, only: :index do
-    get :headers, on: :collection
-  end
+  resources :home, only: :index
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,34 +1,29 @@
 require 'spec_helper'
 
 describe "integration", type: :request do
-  describe 'index' do
-    it 'accepts :params' do
-      get "/home", params: { text: 'Hello World!' }
+  it 'accepts :params' do
+    get "/home", params: { text: 'Hello World!' }
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('Text: Hello World!')
-    end
-
-  describe 'headers'
-    it 'accepts headers' do
-      get "/home", headers: { 'HTTP_ACCEPT' => 'text/plain' }
-
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('Accept: text/plain')
-    end
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Text: Hello World!')
   end
 
-  describe 'raise on offense' do
-    it 'raises when an unexpected parameter is passed' do
-      expect {
-        get "/home", wrong: true
-      }.to raise_error(RailsTestParamsBackport::ParameterError)
-    end
+  it 'accepts headers' do
+    get "/home", headers: { 'HTTP_ACCEPT' => 'text/plain' }
 
-    it 'raises when headers are sent in a separate hash' do
-      expect {
-        get "/home", {}, { 'HTTP_ACCEPT' => 'text/plain' }
-      }.to raise_error(RailsTestParamsBackport::ParameterError)
-    end
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Accept: text/plain')
+  end
+
+  it 'raises when an unexpected parameter is passed' do
+    expect {
+      get "/home", wrong: true
+    }.to raise_error(RailsTestParamsBackport::ParameterError)
+  end
+
+  it 'raises when headers are sent in a separate hash' do
+    expect {
+      get "/home", {}, { 'HTTP_ACCEPT' => 'text/plain' }
+    }.to raise_error(RailsTestParamsBackport::ParameterError)
   end
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe "integration", type: :request do
+  it 'accepts the path alone' do
+    get "/home"
+
+    expect(response).to have_http_status(:ok)
+  end
+
   it 'accepts :params' do
     get "/home", params: { text: 'Hello World!' }
 

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -6,15 +6,15 @@ describe "integration", type: :request do
       get "/home", params: { text: 'Hello World!' }
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq('params[:text] = Hello World!')
+      expect(response.body).to include('Text: Hello World!')
     end
 
   describe 'headers'
     it 'accepts headers' do
-      get "/home/headers", headers: { 'HTTP_ACCEPT' => 'text/plain' }
+      get "/home", headers: { 'HTTP_ACCEPT' => 'text/plain' }
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq('session[:accept] = text/plain')
+      expect(response.body).to include('Accept: text/plain')
     end
   end
 


### PR DESCRIPTION
Slightly simpler test app and (imho) more readable specs.

(`w=1` is your friend when reading the diffs: https://github.com/zendesk/rails_test_params_backport/commit/88afd8a8962eb1a84451e2d36fb9f4de9ef89e5b?w=1)

@pschambacher @grosser 
